### PR TITLE
fix: strapi 5 compatibility

### DIFF
--- a/server/src/controllers/index-all.ts
+++ b/server/src/controllers/index-all.ts
@@ -67,7 +67,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       (locale: any) => locale.code
     );
     const findManyBaseOptions = {
-      populate
+      populate,
     };
     const findManyOptions = localeFilter
       ? {
@@ -77,16 +77,23 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       : { ...findManyBaseOptions };
 
     // Can't fetch draft & published articles in the same query (no status filter = draft only)
-    const publishedArticlesStrapi = await strapi
-      .documents(name as UID.ContentType)
-      .findMany({...findManyOptions, status: 'published'}) ?? [];
-    const draftArticlesStrapi = await strapi
-      .documents(name as UID.ContentType)
-      .findMany({...findManyOptions, status: 'draft'}) ?? [];
+    const publishedArticlesStrapi =
+      (await strapi
+        .documents(name as UID.ContentType)
+        .findMany({ ...findManyOptions, status: 'published' })) ?? [];
+    const draftArticlesStrapi =
+      (await strapi
+        .documents(name as UID.ContentType)
+        .findMany({ ...findManyOptions, status: 'draft' })) ?? [];
     // Concatenate all published articles + any draft versions which aren't published
     // Filtering out any draft articles which have a published version
-    const articlesStrapi = publishedArticlesStrapi.concat(draftArticlesStrapi.filter(
-      (draft: any) => !publishedArticlesStrapi.some((published: any) => published.id === draft.id))
+    const articlesStrapi = publishedArticlesStrapi.concat(
+      draftArticlesStrapi.filter(
+        (draft: any) =>
+          !publishedArticlesStrapi.some(
+            (published: any) => published.id === draft.id
+          )
+      )
     );
     const articles = (articlesStrapi ?? []).map((article: any) =>
       utilsService.filterProperties(article, hideFields)

--- a/server/src/controllers/index-all.ts
+++ b/server/src/controllers/index-all.ts
@@ -66,7 +66,9 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     const localeFilter = allLocales?.map(
       (locale: any) => locale.code
     );
-    const findManyBaseOptions = { populate };
+    const findManyBaseOptions = {
+      populate
+    };
     const findManyOptions = localeFilter
       ? {
           ...findManyBaseOptions,
@@ -74,9 +76,18 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
         }
       : { ...findManyBaseOptions };
 
-    const articlesStrapi = await strapi
+    // Can't fetch draft & published articles in the same query (no status filter = draft only)
+    const publishedArticlesStrapi = await strapi
       .documents(name as UID.ContentType)
-      .findMany(findManyOptions);
+      .findMany({...findManyOptions, status: 'published'}) ?? [];
+    const draftArticlesStrapi = await strapi
+      .documents(name as UID.ContentType)
+      .findMany({...findManyOptions, status: 'draft'}) ?? [];
+    // Concatenate all published articles + any draft versions which aren't published
+    // Filtering out any draft articles which have a published version
+    const articlesStrapi = publishedArticlesStrapi.concat(draftArticlesStrapi.filter(
+      (draft: any) => !publishedArticlesStrapi.some((published: any) => published.id === draft.id))
+    );
     const articles = (articlesStrapi ?? []).map((article: any) =>
       utilsService.filterProperties(article, hideFields)
     );

--- a/server/src/services/strapi.ts
+++ b/server/src/services/strapi.ts
@@ -21,7 +21,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     }
 
     const strapiObject = await strapi.documents(modelUid).findOne({
-      documentId: entryId,
+      documentId: event.result.documentId,
+      // the documentId can have a published & unpublished version associated
+      // without a status filter, the unpublished version could be returned even if a published on exists,
+      // which would incorrectly de-index.
+      status: 'published',
       populate,
     });
 
@@ -64,7 +68,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
         if (strapiObject.publishedAt === null) {
           objectsIdsToDelete.push(entryId);
-        } else if (strapiObject.publishedAt !== null) {
+        } else {
           objectsToSave.push({
             objectID: entryId,
             ...strapiObject,
@@ -107,7 +111,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
         if (article.publishedAt === null) {
           objectsIdsToDelete.push(entryIdWithPrefix);
-        } else if (article.publishedAt !== null) {
+        } else {
           objectsToSave.push({
             objectID: entryIdWithPrefix,
             ...article,

--- a/tests/strapi-algolia.spec.ts
+++ b/tests/strapi-algolia.spec.ts
@@ -229,7 +229,8 @@ describe('strapi-algolia plugin', () => {
       let strapi: any;
       const fakeArticle = {
         article: {
-          id: 'id',
+          id: 123,
+          documentId: 'id',
           title: 'title',
           content: 'content',
           publishedAt: null,
@@ -238,7 +239,8 @@ describe('strapi-algolia plugin', () => {
       } as any;
       const fakeArticleWithoutHide = {
         article: {
-          id: 'id',
+          id: 123,
+          documentId: 'id',
           title: 'title',
           content: 'content',
           publishedAt: null,
@@ -290,7 +292,8 @@ describe('strapi-algolia plugin', () => {
           strapiService({ strapi }).getStrapiObject(
             {
               result: {
-                id: 'id',
+                id: 123,
+                documentId: 'id',
               },
               model: {
                 uid: 'api::contentType.contentType',
@@ -300,7 +303,7 @@ describe('strapi-algolia plugin', () => {
             []
           )
         ).rejects.toThrow(
-          'No entry found for api::contentType.contentType with ID id'
+          'No entry found for api::contentType.contentType with ID 123'
         );
       });
 
@@ -310,7 +313,8 @@ describe('strapi-algolia plugin', () => {
         }).getStrapiObject(
           {
             result: {
-              id: 'id',
+              id: 123,
+              documentId: 'id',
             },
             model: {
               uid: 'api::contentType.contentType',
@@ -327,6 +331,7 @@ describe('strapi-algolia plugin', () => {
         expect(strapi.documents().findOne).toHaveBeenCalledWith({
           documentId: 'id',
           populate: '*',
+          status: 'published',
         });
       });
 
@@ -337,11 +342,14 @@ describe('strapi-algolia plugin', () => {
           {
             params: {
               where: {
-                id: 'id',
+                id: 123,
               },
             },
             model: {
               uid: 'api::contentType.contentType',
+            },
+            result: {
+              documentId: 'id',
             },
           } as any,
           '*',
@@ -355,6 +363,7 @@ describe('strapi-algolia plugin', () => {
         expect(strapi.documents().findOne).toHaveBeenCalledWith({
           documentId: 'id',
           populate: '*',
+          status: 'published',
         });
       });
 
@@ -365,11 +374,15 @@ describe('strapi-algolia plugin', () => {
           {
             params: {
               where: {
-                id: 'id',
+                id: 123,
+                status: 'published',
               },
             },
             model: {
               uid: 'api::contentType.contentType',
+            },
+            result: {
+              documentId: 'id',
             },
           } as any,
           '*',
@@ -383,6 +396,7 @@ describe('strapi-algolia plugin', () => {
         expect(strapi.documents().findOne).toHaveBeenCalledWith({
           documentId: 'id',
           populate: '*',
+          status: 'published',
         });
       });
     });
@@ -396,10 +410,11 @@ describe('strapi-algolia plugin', () => {
       expect(
         utilsService({ strapi: {} as any }).getEntryId({
           result: {
-            id: 'idresult',
+            documentId: 'idresult',
+            id: 123,
           },
         } as any)
-      ).toEqual('idresult');
+      ).toEqual(123);
       expect(
         utilsService({ strapi: {} as any }).getEntryId({
           params: {


### PR DESCRIPTION
This fix relates to the issue raised in #15, plus another bug I identified while testing my fix for that issue - both of which seem to be caused by some of the strapi changes in version 5.

- Fix index all action unindexing all documents: the default search results were only for draft articles which all had no publishedAt timestamp, causing them to be requested for deletion (https://docs.strapi.io/dev-docs/api/document-service/status).
- Fix individual document create/update handling: a new document (string) ID has been added (which identifies the document across both its draft & published versions), which didn't match the (int) ID being used in the queries. I've updated the query to lookup documents post create/update to use the new documentID so that results get returned, and am filtering to only include published states to ensure the correct version is returned.