### PR TITLE
Fix duplication and locale

### DIFF
--- a/server/src/services/strapi.ts
+++ b/server/src/services/strapi.ts
@@ -19,9 +19,10 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     if (!entryId) {
       throw new Error(`No entry id found in event.`);
     }
-
+    const { documentId, locale } = event.result;
     const strapiObject = await strapi.documents(modelUid).findOne({
-      documentId: event.result.documentId,
+      documentId,
+      locale: typeof locale === "string" && locale.length > 0 ? locale : undefined,
       // the documentId can have a published & unpublished version associated
       // without a status filter, the unpublished version could be returned even if a published on exists,
       // which would incorrectly de-index.
@@ -76,9 +77,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
           // Unreachable code! 
           // `getStrapiObject` returns only the published entry or throws an error
           objectsIdsToDelete.push(entryId);
-        } else if (event.result?.id !== strapiObject.id) {
-          // Ensuring `event.result` is NOT a draft or in another language,
-          // given that `strapiObject` is the published entry (of the primary language)
+        } else if (event.result?.id === strapiObject.id) {
+          // Ensure that the current event is triggered by strapiObject
           objectsToSave.push(
             utilsService.filterProperties(
               {

--- a/server/src/services/strapi.ts
+++ b/server/src/services/strapi.ts
@@ -59,6 +59,10 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
     for (const event of events) {
       try {
+        if (! event.result?.publishedAt) {
+          // event trigger by draft updates
+          continue;
+        }
         const entryId = `${idPrefix}${utilsService.getEntryId(
           event
         )}`;
@@ -69,8 +73,12 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
         );
 
         if (strapiObject.publishedAt === null) {
+          // Unreachable code! 
+          // `getStrapiObject` returns only the published entry or throws an error
           objectsIdsToDelete.push(entryId);
-        } else {
+        } else if (event.result?.id !== strapiObject.id) {
+          // Ensuring `event.result` is NOT a draft or in another language,
+          // given that `strapiObject` is the published entry (of the primary language)
           objectsToSave.push(
             utilsService.filterProperties(
               {


### PR DESCRIPTION
Fixed Issue #28 

Fixed other bugs introduced by using a problematic query to fetch `strapiObject`. The `afterUpdate` and `afterCreate` events are triggered by various actions (e.g. _updating a draft_ or _publishing a record_). The `getStrapiObject()` function uses a query that is different to the query in those actions. For example, when updating a draft or publishing a record in non-default language, `getStrapiObject` always fetches the wrong record because it searches for the wrong state (published) in the wrong language (`locale=default`). Thus, checking `event.result?.id === strapiObject.id` is necessary.

See [this comment](https://github.com/wizbii/strapi-plugin-strapi-algolia/issues/28#issuecomment-2883406747) for more details.
